### PR TITLE
init.mk: error with _VERSION_DIGIT variable

### DIFF
--- a/init.mk
+++ b/init.mk
@@ -1,4 +1,4 @@
-_VERSION_DIGIT := $(shell expr substr $(shell echo '$(MAKE_VERSION)' | tr -d .) 1 1)
+_VERSION_DIGIT := $(shell (echo '$(MAKE_VERSION)' | tr -d .) | cut -c 1-1)
 _VERSION_COMPARE := $(shell echo $$(( $(_VERSION_DIGIT) >= 4)))
 
 ifeq ($(_VERSION_COMPARE),0)


### PR DESCRIPTION
there's an error when you run the make or gmake command:
<img width="546" alt="Screenshot 2020-04-03 at 13 13 38" src="https://user-images.githubusercontent.com/16138690/78355088-686d3180-75ad-11ea-8362-55a5fa7029ae.png">
