### PR TITLE
[git-tag] Support tag version without "v" suffix

### DIFF
--- a/git-tag.sh
+++ b/git-tag.sh
@@ -53,6 +53,11 @@ git_tag() {
     printf "Describe your tag: "
     read -r tag_description
 
+    if [ "$tag_description" = "" ]
+    then
+        tag_description="$1"
+    fi
+
     git tag -a "$1" -m "$tag_description" && echo "Done! Tag successfuly applied"
 }
 


### PR DESCRIPTION
Example repo with current tag version e.g: 1.0.1:

```
$ make git-tag
Current tag version: 1.0.1
Would you like to add "v" suffix to your next tag version?: y
1) v2.0.0 - major
2) v1.1.0 - minor
3) v1.0.2 - bugfix
Choose tag to apply: 2
Describe your tag: my new tag 🚀
Done! Tag successfuly applied
```
or not:

```
$ make git-tag
Current tag version: 1.0.1
Would you like to add "v" suffix to your next tag version?: n
1) 2.0.0 - major
2) 1.1.0 - minor
3) 1.0.2 - bugfix
Choose tag to apply: 2
Describe your tag: my new tag 🚀
Done! Tag successfuly applied
```