### PR TITLE
Add GOLANGCI_EXTRA_ARGS variable

### DIFF
--- a/go.mk
+++ b/go.mk
@@ -22,8 +22,9 @@ GO_TAGS ?=
 GO_BIN_OUTPUT_DIR ?= $(CURDIR)/bin
 GO_BIN_OUTPUT_NAME ?=
 
-GOLANGCI_VERSION ?= v1.24.0
-GOLANGCI_TIMEOUT ?= 5m
+GOLANGCI_VERSION	?= v1.24.0
+GOLANGCI_TIMEOUT	?= 5m
+GOLANGCI_EXTRA_ARGS	?=
 
 GO_MAIN_PKG_PATH ?= .
 
@@ -40,7 +41,7 @@ vet: ## Run go vet
 
 .PHONY: lint
 lint: installgolangcilint ## Lint go code
-	golangci-lint run --modules-download-mode=$(GO_VENDOR_DIR) --timeout $(GOLANGCI_TIMEOUT) ./...
+	golangci-lint run --modules-download-mode=$(GO_VENDOR_DIR) --timeout $(GOLANGCI_TIMEOUT) $(GOLANGCI_EXTRA_ARGS) ./...
 
 
 .PHONY: test test-verbose


### PR DESCRIPTION
This change introduces a new `GOLANGCI_EXTRA_ARGS` variable that may be
used to provde additional arguments to the `golangci-lint` command.