### PR TITLE
Add "public" sub-Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ And then:
       [...]
 
 
+#### `release`
+
+The `release` target requires a `PROJECT_URL` Makefile variable set to the HTTP
+URL of the project repository, e.g. `https://github.com/alice/cool_project`.
+
 ## Extendable targets
 
 An extendable target is a `make` target (`build`, `vet`, `lint` ...) which can

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 This repository is an attempt to act as a GNU make common ground for exoscale's Go projects.
 
+
 ## Installation
 
 ### Requirements
 
 You need to use GNU make (also known as `gmake`) version 3.82+, ideally 4+.
+
 
 ### Adding the required git submodule
 
@@ -21,6 +23,7 @@ For more informations about git submodules please refer to the documentation
 page :
 
 - https://git-scm.com/book/en/v2/Git-Tools-Submodules
+
 
 ### Initializing go.mk
 
@@ -70,12 +73,14 @@ The output of `make dumpvariables` should look like this:
     GO_TAGS                 = 
     GO_BIN_OUTPUT_DIR       = /home/jerome/.go/src/github.com/[...]/bin
     
+
 ### Updating the submodule
 
 If ever you want to fetch new changes in `go.mk` and the git submodule is
 already installed, you can simply fetch updates by using the following command:
 
     git submodule update --remote go.mk
+
 
 ## Configuration
 
@@ -107,6 +112,26 @@ And then:
 Any variable you want to override must be declared BEFORE including `go.mk/init.mk`
 
 
+### "Public" targets
+
+If a *public* project (i.e. Open Source project repository hosted in a public
+GitHub) uses `go.mk`, it can include the `public.mk` Makefile to access
+public-only targets such as `release`, that calls [GoReleaser][goreleaser] in
+order to handle releases of the project according to the configuration set in
+the `.goreleaser.yml` file.
+
+    include ./go.mk/init.mk
+    include ./go.mk/public.mk
+
+And then:
+
+    ➜ make git-tag
+      # Set a new Git tag
+    ➜ git push --tags
+    ➜ make release
+      [...]
+
+
 ## Extendable targets
 
 An extendable target is a `make` target (`build`, `vet`, `lint` ...) which can
@@ -134,3 +159,6 @@ And then call `make clean` and you should see something like this:
 
     rm -rf [...]
     I will be called as well
+
+
+[goreleaser]: https://goreleaser.com/

--- a/coverage.mk
+++ b/coverage.mk
@@ -4,7 +4,7 @@ GO_COVERAGE_DIR ?= $(CURDIR)/coverage
 
 .PHONY: test-coverage
 .ONESHELL:
-test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles ## Run tests with coverage enabled
+test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles ## Runs tests with coverage enabled
 
 
 .PHONY: $(GO_COVERAGE_DIR)

--- a/go.mk
+++ b/go.mk
@@ -35,18 +35,18 @@ export GO111MODULE=on
 # ---
 
 .PHONY: vet
-vet: ## Run go vet
+vet: ## Runs `go vet`
 	$(GO) vet ./...
 
 
 .PHONY: lint
-lint: installgolangcilint ## Lint go code
+lint: installgolangcilint ## Lints Go code
 	golangci-lint run --modules-download-mode=$(GO_VENDOR_DIR) --timeout $(GOLANGCI_TIMEOUT) $(GOLANGCI_EXTRA_ARGS) ./...
 
 
 .PHONY: test test-verbose
-test: 				                ## Run go tests in silent mode
-test-verbose: GO_TEST_EXTRA_ARGS=-v ## Run go tests in verbose mode
+test: 				                ## Runs Go tests in silent mode
+test-verbose: GO_TEST_EXTRA_ARGS=-v ## Runs Go tests in verbose mode
 test test-verbose:
 	$(GO) test                      \
 		-race                       \
@@ -57,8 +57,8 @@ test test-verbose:
 
 
 .PHONY: build build-verbose
-build-verbose: GO_BUILD_EXTRA_ARGS=-v  						## Builds a go binary in verbose mode
-build:            											## Builds a go binary in silent mode
+build-verbose: GO_BUILD_EXTRA_ARGS=-v  						## Builds a Go binary in verbose mode
+build:            											## Builds a Go binary in silent mode
 build build-verbose: $(GO_BIN_OUTPUT_DIR) createvendordir
 	$(GO) build                                       \
 		$(GO_BUILD_EXTRA_ARGS)                        \
@@ -70,12 +70,12 @@ build build-verbose: $(GO_BIN_OUTPUT_DIR) createvendordir
 
 
 .PHONY: clean
-clean::	## Removes compiled go binaries
+clean::	## Removes compiled Go binaries
 	rm -rf $(GO_BIN_OUTPUT_DIR)
 
 
 .PHONY: clean-gocache
-clean-gocache: ## Removes go's module and test cache
+clean-gocache: ## Removes Go's module and test cache
 	$(GO) clean -cache -testcache
 
 
@@ -101,11 +101,11 @@ createvendordir:
 
 .PHONY: fmt
 .ONESHELL:
-fmt:  ## Formats source files
+fmt:  ## Formats Go source files
 	@for d in $(shell go list -f '{{.Dir}}' ./...);do
 		$(GOIMPORTS) -w $$d/*.go
 	done
 
 .PHONY: git-tag
-git-tag: ## Creates a git tag
+git-tag: ## Creates a Git tag
 	@$(INCLUDE_PATH)/git-tag.sh

--- a/public.mk
+++ b/public.mk
@@ -1,0 +1,3 @@
+release: SHELL:=/bin/bash
+release:
+	goreleaser --release-notes <(echo "See the [CHANGELOG](https://$(PACKAGE)/blob/v$(VERSION)/CHANGELOG.md) for details.")

--- a/public.mk
+++ b/public.mk
@@ -1,3 +1,4 @@
+.PHONY: release
 release: SHELL:=/bin/bash
 release:
 	goreleaser --release-notes <(echo "See the [CHANGELOG](https://$(PACKAGE)/blob/v$(VERSION)/CHANGELOG.md) for details.")

--- a/public.mk
+++ b/public.mk
@@ -1,4 +1,19 @@
+GORELEASER_VERSION  ?= v0.138.0
+GORELEASER_OPTS     ?= --release-notes <(echo "See the [CHANGELOG](https://$(PACKAGE)/blob/v$(VERSION)/CHANGELOG.md) for details.")
+
+.PHONY: installgoreleaser
+.ONESHELL:
+installgoreleaser: ## Installs GoReleaser (https://goreleaser.com/)
+	if [ ! -f $(shell go env GOPATH)/bin/goreleaser ]; then
+		curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | \
+			sh -s -- -b $(shell go env GOPATH)/bin $(GORELEASER_VERSION)
+	fi
+
 .PHONY: release
 release: SHELL:=/bin/bash
-release:
-	goreleaser --release-notes <(echo "See the [CHANGELOG](https://$(PACKAGE)/blob/v$(VERSION)/CHANGELOG.md) for details.")
+release: installgoreleaser ## Releases new project version using `goreleaser`
+	if [ -z "$(PROJECT_URL)" ] ; then
+		echo 'ERROR: Makefile variable PROJECT_URL must be set in order to use the "release" target'
+		exit 1
+	fi
+	goreleaser $(GORELEASER_OPTS)

--- a/public.mk
+++ b/public.mk
@@ -10,6 +10,7 @@ installgoreleaser: ## Installs GoReleaser (https://goreleaser.com/)
 	fi
 
 .PHONY: release
+.ONESHELL:
 release: SHELL:=/bin/bash
 release: installgoreleaser ## Releases new project version using `goreleaser`
 	if [ -z "$(PROJECT_URL)" ] ; then


### PR DESCRIPTION
This change introduces a new `public.mk` sub-Makefile that can be
included to access targets useful for public projects.