### PR TITLE
Thorough overhaul (consolidation/cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The output of `make help` should look like this:
     installgolangcilint            Installs golangcilint (https://golangci.com/)
     lint                           Lint go code
     test                           Run go tests in silent mode
-    test-verbose                   Run go tests in verbose mode 
+    test-verbose                   Run go tests in verbose mode
     vet                            Run go vet
 
 The output of `make dumpvariables` should look like this:
@@ -72,7 +72,7 @@ The output of `make dumpvariables` should look like this:
     GO_TEST_TIMEOUT         = 15s
     GO_TAGS                 = 
     GO_BIN_OUTPUT_DIR       = /home/jerome/.go/src/github.com/[...]/bin
-    
+
 
 ### Updating the submodule
 

--- a/coverage.mk
+++ b/coverage.mk
@@ -1,51 +1,59 @@
+## GoLang tests coverage
+
 GO_COVERAGE_DIR ?= $(CURDIR)/coverage
 
-# ---
-
-.PHONY: test-coverage
-.ONESHELL:
-test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles ## Runs tests with coverage enabled
+GOCOV ?= $(shell which gocov)
+GOCOV_XML ?= $(shell which gocov-xml)
+GOCOVMERGE ?= $(shell which gocovmerge)
 
 
-.PHONY: $(GO_COVERAGE_DIR)
-$(GO_COVERAGE_DIR):
-	test -d $(GO_COVERAGE_DIR) || mkdir $(GO_COVERAGE_DIR)
+## Targets
 
-
-.PHONY: run-test-with-coverage
-.ONESHELL:
-run-test-with-coverage:
-	for pkg in $(GO_TEST_PKGS); do
-		$(GO) test            			\
-			-race             			\
-			-cover            			\
-			-timeout $(GO_TEST_TIMEOUT) \
-			-coverpkg=./...   			\
-			-covermode=atomic 			\
-			-coverprofile="$(GO_COVERAGE_DIR)/`echo $$pkg | tr "/" "-"`.out" $$pkg
-	done
-
-
-GO_COVERAGE_OUTPUT_MERGED = $(GO_COVERAGE_DIR)/all.out
-GO_COVERAGE_OUTPUT_XML = $(GO_COVERAGE_DIR)/coverage.xml
-GO_COVERAGE_OUTPUT_HTML = $(GO_COVERAGE_DIR)/index.html
-.PHONY: gen-coverage-profiles
-.ONESHELL:
-gen-coverage-profiles: install-coverage-requirements
-	gocovmerge $(GO_COVERAGE_DIR)/*.out > $(GO_COVERAGE_OUTPUT_MERGED)
-	$(GO) tool cover -html=$(GO_COVERAGE_OUTPUT_MERGED) -o $(GO_COVERAGE_OUTPUT_HTML)
-	gocov convert $(GO_COVERAGE_OUTPUT_MERGED) | gocov-xml > $(GO_COVERAGE_OUTPUT_XML)
-	rm $(GO_COVERAGE_DIR)/*.out
-
+# Dependencies
 
 .PHONY:
 .ONESHELL:
 install-coverage-requirements:
 	export GO111MODULE=off
-	which gocov      > /dev/null || go get github.com/axw/gocov/gocov
-	which gocov-xml  > /dev/null || go get github.com/AlekSi/gocov-xml
-	which gocovmerge > /dev/null || go get github.com/wadey/gocovmerge
+	'$(GO)' get github.com/axw/gocov/gocov
+	'$(GO)' get github.com/AlekSi/gocov-xml
+	'$(GO)' get github.com/wadey/gocovmerge
 
+# Coverage
+
+.PHONY: test-coverage
+.ONESHELL:
+test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles
+
+.PHONY: $(GO_COVERAGE_DIR)
+$(GO_COVERAGE_DIR):
+	mkdir -p '$(GO_COVERAGE_DIR)'
+
+.PHONY: run-test-with-coverage
+.ONESHELL:
+run-test-with-coverage:
+	for pkg in $(GO_TEST_PKGS); do
+	  '$(GO)' test \
+	    -race \
+	    -cover \
+	    -timeout $(GO_TEST_TIMEOUT) \
+	    -coverpkg=./... \
+	    -covermode=atomic \
+	    -coverprofile="$(GO_COVERAGE_DIR)/$$(echo $${pkg} | tr '/' '-').out" "$${pkg}"
+	done
+
+GO_COVERAGE_OUTPUT_MERGED = $(GO_COVERAGE_DIR)/all.out
+GO_COVERAGE_OUTPUT_XML = $(GO_COVERAGE_DIR)/coverage.xml
+GO_COVERAGE_OUTPUT_HTML = $(GO_COVERAGE_DIR)/index.html
+.PHONY: gen-coverage-profiles
+gen-coverage-profiles: install-coverage-requirements
+	'$(GOCOVMERGE)' '$(GO_COVERAGE_DIR)'/*.out > '$(GO_COVERAGE_OUTPUT_MERGED)'
+	'$(GO)' tool cover -html '$(GO_COVERAGE_OUTPUT_MERGED)' -o '$(GO_COVERAGE_OUTPUT_HTML)'
+	'$(GOCOV)' convert '$(GO_COVERAGE_OUTPUT_MERGED)' | '$(GOCOV_XML)' > '$(GO_COVERAGE_OUTPUT_XML)'
+	rm -f '$(GO_COVERAGE_DIR)'/*.out
+	@echo Please visit '$(GO_COVERAGE_DIR)/index.html'
+
+# Clean
 
 clean::
-	rm -rf $(GO_COVERAGE_DIR)
+	rm -rf '$(GO_COVERAGE_DIR)'

--- a/fmt.mk
+++ b/fmt.mk
@@ -1,0 +1,24 @@
+## Go Imports (formatter)
+#  REF: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+
+GOIMPORTS_VERSION ?= v0.1.10
+
+GOIMPORTS ?= $(shell which goimports)
+
+
+## Targets
+
+# Dependencies
+
+.PHONY: install-goimports
+install-goimports:
+	'$(GO)' install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+
+# Format
+
+.PHONY: fmt
+.ONESHELL:
+fmt: install-goimports
+	IFS=$$'\n'; for dir in $(shell go list -f '{{.Dir}}' ./...); do
+	  '$(GOIMPORTS)' -w "$${dir}"/*.go
+	done

--- a/init.mk
+++ b/init.mk
@@ -21,12 +21,15 @@ endif
 
 all: help
 
+# Allow default targets to be overridden in external Makefiles:
+%: %-default
+	@true
+
 # ---
 
 include $(INCLUDE_PATH)/version.mk
 include $(INCLUDE_PATH)/os.mk
 include $(INCLUDE_PATH)/go.mk
-include $(INCLUDE_PATH)/coverage.mk
 
 # ---
 

--- a/lint.mk
+++ b/lint.mk
@@ -1,0 +1,28 @@
+## GoLang CI Linter
+#  REF: https://github.com/golangci/golangci-lint/
+
+GOLANGCI_LINT_VERSION ?= v1.45.2
+GOLANGCI_LINT_TIMEOUT ?= 5m
+GOLANGCI_LINT_EXTRA_ARGS ?=
+
+GOLANGCI_LINT ?= $(shell which golangci-lint)
+
+
+## Targets
+
+# Dependencies
+
+.PHONY: install-golangci-lint installgolangcilint
+installgolangcilint: install-golangci-lint
+install-golangci-lint:
+	'$(GO)' install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+# Lint
+
+.PHONY: lint
+lint: install-golangci-lint
+	'$(GOLANGCI_LINT)' run \
+	  --modules-download-mode=vendor \
+	  --timeout $(GOLANGCI_LINT_TIMEOUT) \
+	  $(GOLANGCI_LINT_EXTRA_ARGS) \
+	  ./...

--- a/os.mk
+++ b/os.mk
@@ -1,9 +1,9 @@
-OS =		$(shell uname -s | awk '{print tolower($$0)}')
-ARCH =		$(shell uname -p)
-SED =		$(shell which sed)
-
 ifeq ($(shell uname -s),Darwin)
-	OS =		darwin
-	ARCH =		amd64
-	SED =		$(shell which gsed)
+	OS := darwin
+	ARCH := amd64
+	SED := $(shell which gsed)
+else
+	OS := $(shell uname -s | awk '{print tolower($$0)}')
+	ARCH := $(shell uname -p)
+	SED := $(shell which sed)
 endif

--- a/public.mk
+++ b/public.mk
@@ -1,17 +1,13 @@
-GORELEASER_VERSION  ?= v1.7.0
-GORELEASER_OPTS     ?= --rm-dist --release-notes <(echo "See the [CHANGELOG]($(PROJECT_URL)/blob/v$(VERSION)/CHANGELOG.md) for details.")
+## Public projects
 
-.PHONY: installgoreleaser
-.ONESHELL:
-installgoreleaser: ## Installs GoReleaser (https://goreleaser.com/)
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
+ifndef INCLUDE_PATH
+	ifeq ($(notdir $(PWD)), go.mk)
+		INCLUDE_PATH := $(PWD)
+	else
+		INCLUDE_PATH := $(PWD)/go.mk
+	endif
+endif
 
-.PHONY: release
-.ONESHELL:
-release-default: SHELL:=/bin/bash
-release-default: installgoreleaser ## Releases new project version using `goreleaser`
-	if [ -z "$(PROJECT_URL)" ] ; then
-		echo 'ERROR: Makefile variable PROJECT_URL must be set in order to use the "release" target'
-		exit 1
-	fi
-	goreleaser $(GORELEASER_OPTS)
+# Dependencies
+
+include $(INCLUDE_PATH)/release.mk

--- a/release.mk
+++ b/release.mk
@@ -1,0 +1,44 @@
+## GoReleaser
+#  REF: https://github.com/goreleaser/goreleaser/
+
+GORELEASER_VERSION ?= v1.7.0
+GORELEASER_OPTS ?= \
+	--rm-dist \
+	--release-notes <(echo "See the [CHANGELOG]($(PROJECT_URL)/blob/v$(VERSION)/CHANGELOG.md) for details.")
+
+GORELEASER ?= $(shell which goreleaser)
+
+
+## Targets
+
+# Dependencies
+
+.PHONY: install-goreleaser installgoreleaser
+installgoreleaser: install-goreleaser
+install-goreleaser:
+	echo Installing/updating 'goreleaser' executable
+	'$(GO)' install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
+
+# Release
+
+.PHONY: git-tag
+git-tag:
+ifdef DRYRUN
+	@echo 'DRY-RUN: '"'"'$(INCLUDE_PATH)/git-tag.sh'"'"''
+else
+	'$(INCLUDE_PATH)/git-tag.sh'
+endif
+
+.PHONY: release-default
+release-default:
+ifndef VERSION
+	$(error Undefined variable VERSION)
+else ifeq ($(VERSION), dev)
+	$(error Releasing the 'dev' VERSION is forbidden)
+else ifndef PROJECT_URL
+	$(error Undefined variable PROJECT_URL)
+else ifdef DRYRUN
+	@echo 'DRY-RUN: '"'"'$(GORELEASER)'"'"' release $(GORELEASER_OPTS)'
+else
+	'$(GORELEASER)' release $(GORELEASER_OPTS)
+endif

--- a/version.mk
+++ b/version.mk
@@ -1,8 +1,10 @@
+## Versioning
+#  (derived from the latest Git commit tag)
+
 VERSION := $(shell git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null | sed 's/^v//')
 ifndef VERSION
-    VERSION = dev
+	VERSION = dev
 endif
 
-GIT_BRANCH := 	$(shell git rev-parse --abbrev-ref HEAD || echo 'n/a')
-
-GIT_REVISION :=	$(shell git rev-parse --short HEAD || echo 'n/a')
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD || echo 'n/a')
+GIT_REVISION := $(shell git rev-parse --short HEAD || echo 'n/a')


### PR DESCRIPTION
# Description

* Split each part - especially in regards with upstream dependencies - in its own `<part>.mk` file
* Harden the release process (along additional verbosity; add DRYRUN mode)
* Don't hide commands being run (remove `@` prefixes) <-> ease troubleshooting/onboarding
* Harden against paths potentially containing white spaces (always surround with quotes)
* Don't attempt alignment (with tabs, which width may vary across environments)

## Testing done (using [packer-plugin-exoscale](https://github.com/exoscale/packer-plugin-exoscale) repository):

```
* [go-1.18] cdufour@xps13-9380.cedric.exoscale.me:~/git/exoscale/packer-plugin-exoscale (main)
$ git submodule status -- go.mk
+e119f45f39794bf59650d71ffa1421b718b18d6a go.mk (remotes/origin/cedric/thorough-overhaul)

$ make help
build                          Builds a Go binary in silent mode
build-verbose                  Builds a Go binary in verbose mode
dumpvariables                  Dump configuration variables
help                           Shows this help
test-acc                       Runs acceptance tests (requires valid Exoscale API credentials)
test-coverage                  Runs tests with coverage enabled
test                           Runs Go tests in silent mode
test-verbose                   Runs Go tests in verbose mode

$ make dumpvariables 
MAKE_VERSION            = 4.3
OS                      = linux
ARCH                    = unknown
SED                     = /usr/bin/sed
SHELL                   = /bin/sh

INCLUDE_PATH            = /home/cdufour/git/exoscale/packer-plugin-exoscale/go.mk

GIT_REVISION            = 8abcb36
GIT_BRANCH              = main
VERSION                 = dev

GO                      = /opt/cdufour/go/1.18/bin/go
GO_VERSION              = go version go1.18 linux/amd64
GO_LD_FLAGS             = -ldflags -X main.commit=8abcb36 -X main.branch=main -X main.buildDate=2022-03-28T09:42:23+0000 -X main.version=dev 
GO_PKGS                 = github.com/exoscale/packer-plugin-exoscale github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import
GO_TEST_PKGS            = github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import
GO_TEST_TIMEOUT         = 15s
GO_TAGS                 = 
GO_BIN_OUTPUT_DIR       = /local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin

$ make fmt
'/opt/cdufour/go/1.18/bin/go' install golang.org/x/tools/cmd/goimports@v0.1.10
IFS=$'\n'; for dir in /home/cdufour/git/exoscale/packer-plugin-exoscale /home/cdufour/git/exoscale/packer-plugin-exoscale/builder/exoscale /home/cdufour/git/exoscale/packer-plugin-exoscale/post-processor/exoscale-import; do
'/home/cdufour/go/bin/goimports' -w "${dir}"/*.go
done

$ make lint 
'/opt/cdufour/go/1.18/bin/go' install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
'/home/cdufour/go/bin/golangci-lint' run \
  --modules-download-mode=vendor \
  --timeout 5m \
   \
  ./...

$ make test
'/opt/cdufour/go/1.18/bin/go' test \
  -race \
  -mod vendor \
  -timeout 15s \
  -parallel 3 -count=1 -failfast \
  github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import
ok  	github.com/exoscale/packer-plugin-exoscale/builder/exoscale	0.061s
ok  	github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import	0.065s

$ make test-coverage 
mkdir -p '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'
for pkg in github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import; do
'/opt/cdufour/go/1.18/bin/go' test \
    -race \
    -cover \
    -timeout 15s \
    -coverpkg=./... \
    -covermode=atomic \
    -coverprofile="/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/$(echo ${pkg} | tr '/' '-').out" "${pkg}"
done
ok  	github.com/exoscale/packer-plugin-exoscale/builder/exoscale	0.063s	coverage: 67.6% of statements in ./...
ok  	github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import	0.060s	coverage: 51.0% of statements in ./...
export GO111MODULE=off
'/opt/cdufour/go/1.18/bin/go' get github.com/axw/gocov/gocov
'/opt/cdufour/go/1.18/bin/go' get github.com/AlekSi/gocov-xml
'/opt/cdufour/go/1.18/bin/go' get github.com/wadey/gocovmerge
'/home/cdufour/go/bin/gocovmerge' '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'/*.out > '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out'
'/opt/cdufour/go/1.18/bin/go' tool cover -html '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out' -o '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/index.html'
'/home/cdufour/go/bin/gocov' convert '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out' | '/home/cdufour/go/bin/gocov-xml' > '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/coverage.xml'
rm -f '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'/*.out
echo Please visit '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/index.html'
Please visit /local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/index.html

$ make build
mkdir -p '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin'
'/opt/cdufour/go/1.18/bin/go' build \
   \
  -ldflags "-X main.commit=8abcb36 -X main.branch=main -X main.buildDate=2022-03-28T09:42:53+0000 -X main.version=dev " \
   \
  -mod vendor \
  -o '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' \
  '.'

$ DRYRUN=yes make git-tag
DRY-RUN: '/home/cdufour/git/exoscale/packer-plugin-exoscale/go.mk/git-tag.sh'

$ DRYRUN=yes make release
/home/cdufour/git/exoscale/packer-plugin-exoscale/go.mk/release.mk:37: *** Releasing the 'dev' VERSION is forbidden.  Stop.
@ 2022-03-28 11:43:13 +0200
```