### PR TITLE
Actual file/dir targets should not be .PHONY

### DIFF
--- a/coverage.mk
+++ b/coverage.mk
@@ -25,7 +25,6 @@ install-coverage-requirements:
 .ONESHELL:
 test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles
 
-.PHONY: $(GO_COVERAGE_DIR)
 $(GO_COVERAGE_DIR):
 	mkdir -p '$(GO_COVERAGE_DIR)'
 
@@ -46,7 +45,7 @@ GO_COVERAGE_OUTPUT_MERGED = $(GO_COVERAGE_DIR)/all.out
 GO_COVERAGE_OUTPUT_XML = $(GO_COVERAGE_DIR)/coverage.xml
 GO_COVERAGE_OUTPUT_HTML = $(GO_COVERAGE_DIR)/index.html
 .PHONY: gen-coverage-profiles
-gen-coverage-profiles: install-coverage-requirements
+gen-coverage-profiles $(GO_COVERAGE_OUTPUT_HTML): install-coverage-requirements
 	'$(GOCOVMERGE)' '$(GO_COVERAGE_DIR)'/*.out > '$(GO_COVERAGE_OUTPUT_MERGED)'
 	'$(GO)' tool cover -html '$(GO_COVERAGE_OUTPUT_MERGED)' -o '$(GO_COVERAGE_OUTPUT_HTML)'
 	'$(GOCOV)' convert '$(GO_COVERAGE_OUTPUT_MERGED)' | '$(GOCOV_XML)' > '$(GO_COVERAGE_OUTPUT_XML)'

--- a/go.mk
+++ b/go.mk
@@ -66,14 +66,13 @@ test test-verbose:
 
 # Build
 
-.PHONY: $(GO_BIN_OUTPUT_DIR)
 $(GO_BIN_OUTPUT_DIR):
 	mkdir -p '$(GO_BIN_OUTPUT_DIR)'
 
 .PHONY: build build-verbose
 build:  ## Builds a Go binary in silent mode
 build-verbose: GO_BUILD_EXTRA_ARGS=-v  ## Builds a Go binary in verbose mode
-build build-verbose: $(GO_BIN_OUTPUT_DIR)
+build build-verbose $(GO_BIN_OUTPUT_DIR)/$(GO_BIN_OUTPUT_NAME): $(GO_BIN_OUTPUT_DIR)
 	'$(GO)' build \
 	  $(GO_BUILD_EXTRA_ARGS) \
 	  $(GO_LD_FLAGS) \


### PR DESCRIPTION
Thus preventing existing targets to be run (unnecessarily) anew