### PR TITLE
FIX release target (and stay clear *SHELL tricks)

### DIFF
--- a/coverage.mk
+++ b/coverage.mk
@@ -12,33 +12,29 @@ GOCOVMERGE ?= $(shell which gocovmerge)
 # Dependencies
 
 .PHONY:
-.ONESHELL:
 install-coverage-requirements:
-	export GO111MODULE=off
-	'$(GO)' get github.com/axw/gocov/gocov
-	'$(GO)' get github.com/AlekSi/gocov-xml
-	'$(GO)' get github.com/wadey/gocovmerge
+	GO111MODULE=off '$(GO)' get github.com/axw/gocov/gocov
+	GO111MODULE=off '$(GO)' get github.com/AlekSi/gocov-xml
+	GO111MODULE=off '$(GO)' get github.com/wadey/gocovmerge
 
 # Coverage
 
 .PHONY: test-coverage
-.ONESHELL:
 test-coverage: $(GO_COVERAGE_DIR) run-test-with-coverage gen-coverage-profiles
 
 $(GO_COVERAGE_DIR):
 	mkdir -p '$(GO_COVERAGE_DIR)'
 
 .PHONY: run-test-with-coverage
-.ONESHELL:
 run-test-with-coverage:
-	for pkg in $(GO_TEST_PKGS); do
+	for pkg in $(GO_TEST_PKGS); do \
 	  '$(GO)' test \
 	    -race \
 	    -cover \
 	    -timeout $(GO_TEST_TIMEOUT) \
 	    -coverpkg=./... \
 	    -covermode=atomic \
-	    -coverprofile="$(GO_COVERAGE_DIR)/$$(echo $${pkg} | tr '/' '-').out" "$${pkg}"
+	    -coverprofile="$(GO_COVERAGE_DIR)/$$(echo $${pkg} | tr '/' '-').out" "$${pkg}"; \
 	done
 
 GO_COVERAGE_OUTPUT_MERGED = $(GO_COVERAGE_DIR)/all.out

--- a/fmt.mk
+++ b/fmt.mk
@@ -17,8 +17,7 @@ install-goimports:
 # Format
 
 .PHONY: fmt
-.ONESHELL:
 fmt: install-goimports
-	IFS=$$'\n'; for dir in $(shell go list -f '{{.Dir}}' ./...); do
-	  '$(GOIMPORTS)' -w "$${dir}"/*.go
+	IFS=$$'\n'; for dir in $(shell go list -f '{{.Dir}}' ./...); do \
+	  '$(GOIMPORTS)' -w "$${dir}"/*.go; \
 	done


### PR DESCRIPTION
Using `.ONESHELL` and `SHELL = ...` have far-ranging effects, beyond that of a single recipe (see [ref](https://www.gnu.org/software/make/manual/make.html#Execution)). One better avoid them.

Consequently, make sure no bash-ism remains in any recipe (in particular the `release-default` one).

Also, DRYRUN now leverages GoReleaser `--snapshot` flag to fully test the release process, short of actually announcing/publishing artefacts.

## Testing done

```
* [go-1.18] cdufour@xps13-9380.cedric.exoscale.me:~/git/exoscale/packer-plugin-exoscale (main)
$ git submodule status -- go.mk
+9229173949cd8e4a6c6248a151a3a04ac3fce544 go.mk (remotes/origin/cedric/avoid-shell-tricks)

$ DRYRUN=yes make release
mkdir -p '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/release'
echo 'See the [CHANGELOG](https://github.com/exoscale/packer-plugin-exoscale/blob/v0.2.1/CHANGELOG.md) for details.' > '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/release/notes.md'
API_VERSION='x5.0' '/home/cdufour/go/bin/goreleaser' release --rm-dist --release-notes '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/release/notes.md' --snapshot
   • releasing...     
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=b50fecdfe5b2737aaf96b06bda84f5701f5fd7dd latest tag=v0.2.1
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag      
   • setting defaults 
   • snapshotting     
      • building snapshot...      version=0.2.1-SNAPSHOT-b50fecd
   • checking distribution directory
   • loading go mod information
   • build prerequisites
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries
      • building                  binary=dist/packer-plugin-exoscale_darwin_amd64/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_darwin_amd64
      • building                  binary=dist/packer-plugin-exoscale_freebsd_amd64/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_freebsd_amd64
      • building                  binary=dist/packer-plugin-exoscale_linux_amd64/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_linux_amd64
      • building                  binary=dist/packer-plugin-exoscale_windows_amd64/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_windows_amd64.exe
   • archives         
      • creating                  archive=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_darwin_amd64.zip
      • creating                  archive=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_freebsd_amd64.zip
      • creating                  archive=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_windows_amd64.zip
      • creating                  archive=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_linux_amd64.zip
   • calculating checksums
   • signing artifacts
      • signing                   artifact=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_freebsd_amd64.zip cmd=gpg signature=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_freebsd_amd64.zip.sig
      • signing                   artifact=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_windows_amd64.zip cmd=gpg signature=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_windows_amd64.zip.sig
      • signing                   artifact=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_linux_amd64.zip cmd=gpg signature=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_linux_amd64.zip.sig
      • signing                   artifact=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_darwin_amd64.zip cmd=gpg signature=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_x5.0_darwin_amd64.zip.sig
      • refreshing checksums      file=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_SHA256SUMS
      • signing                   artifact=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_SHA256SUMS cmd=gpg signature=dist/packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_SHA256SUMS.sig
      • refreshing checksums      file=packer-plugin-exoscale_v0.2.1-SNAPSHOT-b50fecd_SHA256SUMS
   • storing release metadata
      • writing                   file=dist/artifacts.json
      • writing                   file=dist/metadata.json
   • release succeeded after 6.92s

$ make clean
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin'
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/dist'
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/release'
rm -f 'packer-plugin-exoscale'

$ make fmt
'/opt/cdufour/go/1.18/bin/go' install golang.org/x/tools/cmd/goimports@v0.1.10
IFS=$'\n'; for dir in /home/cdufour/git/exoscale/packer-plugin-exoscale /home/cdufour/git/exoscale/packer-plugin-exoscale/builder/exoscale /home/cdufour/git/exoscale/packer-plugin-exoscale/post-processor/exoscale-import; do \
  '/home/cdufour/go/bin/goimports' -w "${dir}"/*.go; \
done

$ make test-coverage 
mkdir -p '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'
for pkg in github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import; do \
  '/opt/cdufour/go/1.18/bin/go' test \
    -race \
    -cover \
    -timeout 15s \
    -coverpkg=./... \
    -covermode=atomic \
    -coverprofile="/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/$(echo ${pkg} | tr '/' '-').out" "${pkg}"; \
done
ok  	github.com/exoscale/packer-plugin-exoscale/builder/exoscale	0.071s	coverage: 67.6% of statements in ./...
ok  	github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import	0.061s	coverage: 51.0% of statements in ./...
GO111MODULE=off '/opt/cdufour/go/1.18/bin/go' get github.com/axw/gocov/gocov
GO111MODULE=off '/opt/cdufour/go/1.18/bin/go' get github.com/AlekSi/gocov-xml
GO111MODULE=off '/opt/cdufour/go/1.18/bin/go' get github.com/wadey/gocovmerge
'/home/cdufour/go/bin/gocovmerge' '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'/*.out > '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out'
'/opt/cdufour/go/1.18/bin/go' tool cover -html '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out' -o '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/index.html'
'/home/cdufour/go/bin/gocov' convert '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/all.out' | '/home/cdufour/go/bin/gocov-xml' > '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/coverage.xml'
rm -f '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'/*.out
Please visit /local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage/index.html
@ 2022-03-29 11:29:35 +0200
```
