### PR TITLE
release: remove API_VERSION requirement

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -55,8 +55,6 @@ ifndef VERSION
 	$(error Undefined variable VERSION)
 else ifndef PROJECT_URL
 	$(error Undefined variable PROJECT_URL)
-else ifndef API_VERSION
-	$(error Undefined variable API_VERSION)
 else
 	API_VERSION='$(API_VERSION)' '$(GORELEASER)' release $(GORELEASER_OPTS)
 endif


### PR DESCRIPTION
API_VERSION is a **project-specific** requirement - e.g. [packer-plugin-exoscale](https://github.com/exoscale/packer-plugin-exoscale/blob/v0.2.1/.goreleaser.yml#L23) - and must not be made _generic_.