### PR TITLE
Remove hard  requirement for vendor folders

### DIFF
--- a/go.mk
+++ b/go.mk
@@ -59,7 +59,6 @@ test-verbose: GO_TEST_EXTRA_ARGS=-v  ## Runs Go tests in verbose mode
 test test-verbose:
 	'$(GO)' test \
 	  -race \
-	  -mod vendor \
 	  -timeout $(GO_TEST_TIMEOUT) \
 	  $(GO_TEST_EXTRA_ARGS) \
 	  $(GO_TEST_PKGS)
@@ -77,7 +76,6 @@ build build-verbose $(GO_BIN_OUTPUT_DIR)/$(GO_BIN_OUTPUT_NAME): $(GO_BIN_OUTPUT_
 	  $(GO_BUILD_EXTRA_ARGS) \
 	  $(GO_LD_FLAGS) \
 	  $(GO_TAGS) \
-	  -mod vendor \
 	  -o '$(GO_BIN_OUTPUT_DIR)/$(GO_BIN_OUTPUT_NAME)' \
 	  '$(GO_MAIN_PKG_PATH)'
 

--- a/lint.mk
+++ b/lint.mk
@@ -22,7 +22,6 @@ install-golangci-lint:
 .PHONY: lint
 lint: install-golangci-lint
 	'$(GOLANGCI_LINT)' run \
-	  --modules-download-mode=vendor \
 	  --timeout $(GOLANGCI_LINT_TIMEOUT) \
 	  $(GOLANGCI_LINT_EXTRA_ARGS) \
 	  ./...


### PR DESCRIPTION
As of [Go 1.14](https://tip.golang.org/doc/go1.14) go tooling will use `vendor` folder automatically if it exist:
```
 When the main module contains a top-level vendor directory and its go.mod file specifies go 1.14 or higher, the go command now defaults to -mod=vendor for operations that accept that flag.
```
This change removes hard requirement for vendoring and allows project maintainers to choose if it should be used or not.