### PR TITLE
release GH action: make login to Docker Hub optional

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -2,10 +2,10 @@ name: "Release"
 inputs:
   registry_username:
     description: 'registry username'
-    required: true
+    required: false
   registry_password:
     description: 'registry password'
-    required: true
+    required: false
   release_github_token:
     description: 'github token with permissions "Contents: read-write" on release repos'
     required: true
@@ -15,6 +15,7 @@ runs:
     - uses: actions/setup-go@v3
 
     - name: Login to Docker Hub
+      if: ${{ inputs.registry_username != '' }} && ${{ inputs.registry_password != '' }}
       uses: docker/login-action@v2
       with:
         username: ${{ inputs.registry_username }}

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-go@v3
 
     - name: Login to Docker Hub
-      if: ${{ inputs.registry_username != '' }} && ${{ inputs.registry_password != '' }}
+      if: inputs.registry_username != '' && inputs.registry_password != ''
       uses: docker/login-action@v2
       with:
         username: ${{ inputs.registry_username }}


### PR DESCRIPTION
Some repositories don't make releases to Docker Hub. We make the password and username for Docker Hub optional and only execute the login step if both are given.