### PR TITLE
publish cli releases as rpm packages on sos

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -7,10 +7,8 @@ RELEASE_NOTES := $(RELEASE_DIR)/notes.md
 # REF: https://github.com/goreleaser/goreleaser/
 
 GORELEASER_VERSION ?= v1.21.2
-# TODO (sc-78178) revert debug flag
 GORELEASER_OPTS ?= \
 	--rm-dist \
-	--debug \
 	--release-notes '$(RELEASE_NOTES)'
 ifneq ($(DRYRUN),)
 GORELEASER_OPTS += --snapshot

--- a/release.mk
+++ b/release.mk
@@ -7,8 +7,10 @@ RELEASE_NOTES := $(RELEASE_DIR)/notes.md
 # REF: https://github.com/goreleaser/goreleaser/
 
 GORELEASER_VERSION ?= v1.21.2
+# TODO (sc-78178) revert debug flag
 GORELEASER_OPTS ?= \
 	--rm-dist \
+	--debug \
 	--release-notes '$(RELEASE_NOTES)'
 ifneq ($(DRYRUN),)
 GORELEASER_OPTS += --snapshot

--- a/scripts/publish-deb-artifact-to-sos.sh
+++ b/scripts/publish-deb-artifact-to-sos.sh
@@ -48,7 +48,9 @@ fi
     aptlydistro=stable
     aptlyconfig="go.mk/scripts/aptly.conf"
     aptlycmd="aptly -config=$aptlyconfig"
-    gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
+    # TODO (sc-78178) revert
+    # gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
+    gpgkeyflag='-skip-signing'
     archflag='-architectures=amd64,arm64,armhf'
 
     # customize aptly.conf

--- a/scripts/publish-deb-artifact-to-sos.sh
+++ b/scripts/publish-deb-artifact-to-sos.sh
@@ -13,6 +13,8 @@ if [ -z "$4" ]; then
 else
     nrversionstokeep=$4
 fi
+# we subtract 1 to account for the added version
+let "nrversionstokeep = $nrversionstokeep - 1"
 
 # Check if the artifact ends with ".deb"
 if [ "${artifact%%.deb}" = "${artifact}" ]; then
@@ -64,6 +66,7 @@ fi
         if [ $first_tag_set ]; then
             package_filter="${package_filter} | "
         fi
+        # TODO (sc-78178) parse the package name from the artifact
         package_filter="${package_filter} exoscale-cli (= ${stripped_tag})"
         first_tag_set=1
     done

--- a/scripts/publish-deb-artifact-to-sos.sh
+++ b/scripts/publish-deb-artifact-to-sos.sh
@@ -15,6 +15,7 @@ else
 fi
 # we subtract 1 to account for the added version
 nrversionstokeep=$((nrversionstokeep - 1))
+projectname=$5
 
 # Check if the artifact ends with ".deb"
 if [ "${artifact%%.deb}" = "${artifact}" ]; then
@@ -48,9 +49,7 @@ fi
     aptlydistro=stable
     aptlyconfig="go.mk/scripts/aptly.conf"
     aptlycmd="aptly -config=$aptlyconfig"
-    # TODO (sc-78178) revert
-    # gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
-    gpgkeyflag='-skip-signing'
+    gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
     archflag='-architectures=amd64,arm64,armhf'
 
     # customize aptly.conf
@@ -68,8 +67,7 @@ fi
         if [ $first_tag_set ]; then
             package_filter="${package_filter} | "
         fi
-        # TODO (sc-78178) parse the package name from the artifact
-        package_filter="${package_filter} exoscale-cli (= ${stripped_tag})"
+        package_filter="${package_filter} ${projectname} (= ${stripped_tag})"
         first_tag_set=1
     done
 

--- a/scripts/publish-deb-artifact-to-sos.sh
+++ b/scripts/publish-deb-artifact-to-sos.sh
@@ -114,5 +114,3 @@ fi
         $aptlyremote
 
 ) 9>/tmp/publish-deb-artifact-to-sos.lock
-
-rm -f /tmp/publish-deb-artifact-to-sos.lock

--- a/scripts/publish-deb-artifact-to-sos.sh
+++ b/scripts/publish-deb-artifact-to-sos.sh
@@ -14,7 +14,7 @@ else
     nrversionstokeep=$4
 fi
 # we subtract 1 to account for the added version
-let "nrversionstokeep = $nrversionstokeep - 1"
+nrversionstokeep=$((nrversionstokeep - 1))
 
 # Check if the artifact ends with ".deb"
 if [ "${artifact%%.deb}" = "${artifact}" ]; then

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -67,7 +67,8 @@ fi
 
     # remove the old signature if it exists
     rm -f ${filetosign}.asc
-    gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
+    # TODO (sc-78178) uncomment
+    # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
 ) 9>/tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env sh
+
+# this script assumes, you are running it from the parent directory of this repository
+
+# set -e
+
+# artifact=$1
+# bucketname=$2
+# repoprefix=$3
+# repoprefixescaped=$(echo $repoprefix | sed 's#/#\\\/#g')
+# if [ -z "$4" ]; then
+#     nrversionstokeep=10
+# else
+#     nrversionstokeep=$4
+# fi
+
+# # Check if the artifact ends with ".deb"
+# if [ "${artifact%%.deb}" = "${artifact}" ]; then
+#     exit 0
+# fi
+
+# # The apt package manager only recognizes 'armhf' as a value for armv6 and armv7 packages.
+# # Since armv6 binaries will run on armv7 cpus, we only publish the armv6 package as the
+# # apt repo cannot have two packages for the 'same' armhf architecture
+# if [ "${artifact%%armv7.deb}" != "${artifact}" ]; then
+#     echo "not publishing armv7 package for debian in favor of armv6 package"
+#     exit 0
+# fi
+
+# # goreleaser executes this script in parallel for each artifact but aptly repos can't be updated in parallel
+# (
+#     # Acquire an exclusive lock on the lock file, or wait until it's available
+#     flock -w 1200 9 || exit 1
+
+#     # install aptly if not available
+#     if ! command -v aptly; then
+#         sudo apt-get update
+#         sudo apt-get install -y aptly
+#     fi
+
+#     aptlyrepo=release-repo
+#     aptlyremote="s3:${bucketname}:"
+#     zone="ch-gva-2"
+#     archiveurl=https://sos-${zone}.exo.io/${bucketname}/${repoprefix}
+#     aptlymirror=${aptlyrepo}-mirror
+#     aptlydistro=stable
+#     aptlyconfig="go.mk/scripts/aptly.conf"
+#     aptlycmd="aptly -config=$aptlyconfig"
+#     gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
+#     archflag='-architectures=amd64,arm64,armhf'
+
+#     # customize aptly.conf
+#     sed -e "s/PLACEHOLDER_FOR_BUCKETNAME/$bucketname/" \
+#         -e "s/PLACEHOLDER_FOR_ZONE/$zone/" \
+#         -e "s/PLACEHOLDER_FOR_PREFIX/${repoprefixescaped}/" ${aptlyconfig}.template >$aptlyconfig
+
+#     # Get the 10 latest Git tags
+#     latest_tags=$(git tag --sort=-v:refname | head -n $nrversionstokeep)
+
+#     # Create a package query filter for aptly
+#     package_filter=""
+#     for tag in $latest_tags; do
+#         stripped_tag=$(expr "$tag" : '.\(.*\)')
+#         if [ $first_tag_set ]; then
+#             package_filter="${package_filter} | "
+#         fi
+#         package_filter="${package_filter} exoscale-cli (= ${stripped_tag})"
+#         first_tag_set=1
+#     done
+
+#     mirrorrepo() {
+#         $aptlycmd mirror create \
+#             $aptlymirror \
+#             $archiveurl \
+#             $aptlydistro
+
+#         $aptlycmd mirror update \
+#             $aptlymirror
+#     }
+
+#     if ! $aptlycmd repo show $aptlyrepo 2>/dev/null; then
+#         isrepounpublished=1
+
+#         $aptlycmd repo create $aptlyrepo
+
+#         if mirrorrepo; then
+#             $aptlycmd repo import $aptlymirror $aptlyrepo "$package_filter"
+#         fi
+#     fi
+
+#     $aptlycmd repo add \
+#         $aptlyrepo \
+#         $artifact
+
+#     if [ $isrepounpublished ]; then
+#         $aptlycmd publish repo \
+#             $gpgkeyflag \
+#             $archflag \
+#             -distribution=$aptlydistro \
+#             $aptlyrepo \
+#             $aptlyremote
+#     fi
+
+#     # this step cleans up package files that are unreferenced
+#     $aptlycmd publish update \
+#         $gpgkeyflag \
+#         $archflag \
+#         $aptlydistro \
+#         $aptlyremote
+
+# ) 9>/tmp/publish-deb-artifact-to-sos.lock
+
+# rm -f /tmp/publish-deb-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -2,7 +2,9 @@
 
 # this script assumes, you are running it from the parent directory of this repository
 
-set -e
+# TODO (sc-78178) revert
+set -ex
+#set -e
 
 artifact=$1
 bucketname=$2

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -70,8 +70,7 @@ fi
     # TODO (sc-78178) uncomment
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
-    $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
-
+    $rclonecmd sync -vv -P "$repodir" "$reponame:${bucketname}/$repoprefix"
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -29,8 +29,6 @@ fi
     fi
 
     reponame=rpmrepo
-    # TODO (sc-78178) remove sauterp
-    bucketname=sauterp-exoscale-packages
     repodir=./rpmrepo/
     rcloneconf=./rclone.config
     rclonecmd="rclone --config=${rcloneconf}"

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # this script assumes, you are running it from the parent directory of this repository
 
@@ -70,7 +70,7 @@ fi
     # TODO (sc-78178) uncomment
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
-    $rclonecmd sync -vv -P "$repodir" "$reponame:${bucketname}/$repoprefix"
+    $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}\/${repoprefix}"
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -71,6 +71,7 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
+
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -2,8 +2,6 @@
 
 # this script assumes, you are running it from the parent directory of this repository
 
-# TODO (sc-78178) revert
-set -ex
 #set -e
 
 artifact=$1
@@ -73,4 +71,4 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
-) 8>publish-rpm-artifact-to-sos.lock
+) 8>/tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -2,112 +2,62 @@
 
 # this script assumes, you are running it from the parent directory of this repository
 
-# set -e
+set -e
 
-# artifact=$1
-# bucketname=$2
-# repoprefix=$3
-# repoprefixescaped=$(echo $repoprefix | sed 's#/#\\\/#g')
-# if [ -z "$4" ]; then
-#     nrversionstokeep=10
-# else
-#     nrversionstokeep=$4
-# fi
+artifact=$1
+bucketname=$2
+repoprefix=$3
 
-# # Check if the artifact ends with ".deb"
-# if [ "${artifact%%.deb}" = "${artifact}" ]; then
-#     exit 0
-# fi
+# Check if the artifact ends with ".rpm"
+if [ "${artifact%%.rpm}" = "${artifact}" ]; then
+    exit 0
+fi
 
-# # The apt package manager only recognizes 'armhf' as a value for armv6 and armv7 packages.
-# # Since armv6 binaries will run on armv7 cpus, we only publish the armv6 package as the
-# # apt repo cannot have two packages for the 'same' armhf architecture
-# if [ "${artifact%%armv7.deb}" != "${artifact}" ]; then
-#     echo "not publishing armv7 package for debian in favor of armv6 package"
-#     exit 0
-# fi
+# goreleaser executes this script in parallel for each artifact but S3 repos can't be updated in parallel
+(
+    # Acquire an exclusive lock on the lock file, or wait until it's available
+    flock -w 1200 9 || exit 1
 
-# # goreleaser executes this script in parallel for each artifact but aptly repos can't be updated in parallel
-# (
-#     # Acquire an exclusive lock on the lock file, or wait until it's available
-#     flock -w 1200 9 || exit 1
+    if ! command -v createrepo_c || ! command -v rclone; then
+        sudo apt-get update
+        sudo apt-get install -y createrepo_c rclone
+    fi
 
-#     # install aptly if not available
-#     if ! command -v aptly; then
-#         sudo apt-get update
-#         sudo apt-get install -y aptly
-#     fi
+    # Get the 10 latest Git tags
+    # latest_tags=$(git tag --sort=-v:refname | head -n $nrversionstokeep)
 
-#     aptlyrepo=release-repo
-#     aptlyremote="s3:${bucketname}:"
-#     zone="ch-gva-2"
-#     archiveurl=https://sos-${zone}.exo.io/${bucketname}/${repoprefix}
-#     aptlymirror=${aptlyrepo}-mirror
-#     aptlydistro=stable
-#     aptlyconfig="go.mk/scripts/aptly.conf"
-#     aptlycmd="aptly -config=$aptlyconfig"
-#     gpgkeyflag='-gpg-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41'
-#     archflag='-architectures=amd64,arm64,armhf'
+    # Create a package query filter for aptly
+    # package_filter=""
+    # for tag in $latest_tags; do
+    #     stripped_tag=$(expr "$tag" : '.\(.*\)')
+    #     if [ $first_tag_set ]; then
+    #         package_filter="${package_filter} | "
+    #     fi
+    #     package_filter="${package_filter} exoscale-cli (= ${stripped_tag})"
+    #     first_tag_set=1
+    # done
 
-#     # customize aptly.conf
-#     sed -e "s/PLACEHOLDER_FOR_BUCKETNAME/$bucketname/" \
-#         -e "s/PLACEHOLDER_FOR_ZONE/$zone/" \
-#         -e "s/PLACEHOLDER_FOR_PREFIX/${repoprefixescaped}/" ${aptlyconfig}.template >$aptlyconfig
+    # TODO (sc-78178) only keep last 10 versions
 
-#     # Get the 10 latest Git tags
-#     latest_tags=$(git tag --sort=-v:refname | head -n $nrversionstokeep)
+    reponame=rpmrepo
+    # TODO (sc-78178) remove sauterp
+    bucketname=sauterp-exoscale-packages
+    repodir=./rpmrepo/
+    rcloneconf=./rclone.config
+    rclonecmd="rclone --config=${rcloneconf}"
+    # TODO (sc-78178) customize
+    #     zone="ch-gva-2"
+    #     archiveurl=https://sos-${zone}.exo.io/${bucketname}/${repoprefix}
+    $rclonecmd config create $reponame s3 provider Other env_auth true endpoint sos-ch-gva-2.exo.io location_constraint ch-gva-2 acl public-read
 
-#     # Create a package query filter for aptly
-#     package_filter=""
-#     for tag in $latest_tags; do
-#         stripped_tag=$(expr "$tag" : '.\(.*\)')
-#         if [ $first_tag_set ]; then
-#             package_filter="${package_filter} | "
-#         fi
-#         package_filter="${package_filter} exoscale-cli (= ${stripped_tag})"
-#         first_tag_set=1
-#     done
+    mkdir -p $repodir
+    $rclonecmd sync -vv -P $reponame:${bucketname}/$repoprefix $repodir
 
-#     mirrorrepo() {
-#         $aptlycmd mirror create \
-#             $aptlymirror \
-#             $archiveurl \
-#             $aptlydistro
+    cp $artifact $repodir
+    createrepo_c $repodir
+    gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor ${repodir}/repodata/repomd.xml
 
-#         $aptlycmd mirror update \
-#             $aptlymirror
-#     }
+    $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
+) 9>/tmp/publish-rpm-artifact-to-sos.lock
 
-#     if ! $aptlycmd repo show $aptlyrepo 2>/dev/null; then
-#         isrepounpublished=1
-
-#         $aptlycmd repo create $aptlyrepo
-
-#         if mirrorrepo; then
-#             $aptlycmd repo import $aptlymirror $aptlyrepo "$package_filter"
-#         fi
-#     fi
-
-#     $aptlycmd repo add \
-#         $aptlyrepo \
-#         $artifact
-
-#     if [ $isrepounpublished ]; then
-#         $aptlycmd publish repo \
-#             $gpgkeyflag \
-#             $archflag \
-#             -distribution=$aptlydistro \
-#             $aptlyrepo \
-#             $aptlyremote
-#     fi
-
-#     # this step cleans up package files that are unreferenced
-#     $aptlycmd publish update \
-#         $gpgkeyflag \
-#         $archflag \
-#         $aptlydistro \
-#         $aptlyremote
-
-# ) 9>/tmp/publish-deb-artifact-to-sos.lock
-
-# rm -f /tmp/publish-deb-artifact-to-sos.lock
+rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # this script assumes, you are running it from the parent directory of this repository
 

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -49,20 +49,20 @@ fi
     pkgname=$(echo $artifact | sed -n 's|.*/\(.*\)_[0-9]*\.[0-9]*\.[0-9]*_linux_.*\.rpm|\1|p')
     pkgarch=$(echo $artifact | sed -n 's|.*/.*_[0-9]*\.[0-9]*\.[0-9]*_linux_\(.*\)\.rpm|\1|p')
 
-    sorted_files=$(ls rpmrepo/${pkgname}_*_linux_${pkgarch}.rpm | sort --version-sort)
+    sorted_files="$(ls ${repodir}/${pkgname}_*_linux_${pkgarch}.rpm | sort --version-sort --reverse)"
 
     # Get the count of all files
     file_count=$(echo "$sorted_files" | wc -l)
 
     # Calculate the number of files to delete
-    let "delete_count = $file_count - $nrversionstokeep"
+    delete_count=$((${file_count} - ${nrversionstokeep}))
 
     if [[ $delete_count -gt 0 ]]; then
         # delete some older versions
         echo "$sorted_files" | head -n $delete_count | xargs -d '\n' rm -f --
     fi
 
-    createrepo_c $repodir
+    createrepo_c "${repodir}"
     filetosign=${repodir}/repodata/repomd.xml
 
     # remove the old signature if it exists

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -74,7 +74,7 @@ fi
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
 
-    sync
+    rm -rf ${repodir}/.repodata
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -21,7 +21,7 @@ fi
 # goreleaser executes this script in parallel for each artifact but S3 repos can't be updated in parallel
 (
     # Acquire an exclusive lock on the lock file, or wait until it's available
-    flock -w 1200 10 || exit 1
+    flock -w 1200 8 || exit 1
 
     if ! command -v createrepo_c || ! command -v rclone; then
         sudo apt-get update
@@ -71,6 +71,6 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
-) 10>/tmp/publish-rpm-artifact-to-sos.lock
+) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -74,5 +74,3 @@ fi
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
 ) 8>publish-rpm-artifact-to-sos.lock
-
-rm -f publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -21,7 +21,7 @@ fi
 # goreleaser executes this script in parallel for each artifact but S3 repos can't be updated in parallel
 (
     # Acquire an exclusive lock on the lock file, or wait until it's available
-    flock -w 1200 9 || exit 1
+    flock -w 1200 10 || exit 1
 
     if ! command -v createrepo_c || ! command -v rclone; then
         sudo apt-get update
@@ -71,6 +71,6 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P $repodir $reponame:${bucketname}/$repoprefix
-) 9>/tmp/publish-rpm-artifact-to-sos.lock
+) 10>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -73,6 +73,8 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
+
+    sync
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -72,7 +72,7 @@ fi
     # TODO (sc-78178) uncomment
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
-    $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}\/${repoprefix}"
+    $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -64,7 +64,7 @@ fi
         echo "$sorted_files" | head -n $delete_count | xargs -d '\n' rm -f --
     fi
 
-    createrepo_c "${repodir}"
+    createrepo_c --ignore-lock "${repodir}"
     filetosign=${repodir}/repodata/repomd.xml
 
     # remove the old signature if it exists
@@ -73,8 +73,6 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
-
-    rm -rf ${repodir}/.repodata
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock
 
 rm -f /tmp/publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -25,7 +25,7 @@ fi
 
     if ! command -v createrepo_c || ! command -v rclone; then
         sudo apt-get update
-        sudo apt-get install -y createrepo_c rclone
+        sudo apt-get install -y createrepo-c rclone
     fi
 
     reponame=rpmrepo

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -73,6 +73,6 @@ fi
     # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
-) 8>/tmp/publish-rpm-artifact-to-sos.lock
+) 8>publish-rpm-artifact-to-sos.lock
 
-rm -f /tmp/publish-rpm-artifact-to-sos.lock
+rm -f publish-rpm-artifact-to-sos.lock

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -64,7 +64,7 @@ fi
         echo "$sorted_files" | head -n $delete_count | xargs -d '\n' rm -f --
     fi
 
-    createrepo_c --ignore-lock "${repodir}"
+    createrepo_c "${repodir}"
     filetosign=${repodir}/repodata/repomd.xml
 
     # remove the old signature if it exists

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -57,7 +57,7 @@ fi
     # Calculate the number of files to delete
     delete_count=$((${file_count} - ${nrversionstokeep}))
 
-    if [[ $delete_count -gt 0 ]]; then
+    if [ $delete_count -gt 0 ]; then
         # delete some older versions
         echo "$sorted_files" | head -n $delete_count | xargs -d '\n' rm -f --
     fi

--- a/scripts/publish-rpm-artifact-to-sos.sh
+++ b/scripts/publish-rpm-artifact-to-sos.sh
@@ -2,7 +2,7 @@
 
 # this script assumes, you are running it from the parent directory of this repository
 
-#set -e
+set -e
 
 artifact=$1
 bucketname=$2
@@ -34,9 +34,6 @@ fi
     repodir=./rpmrepo/
     rcloneconf=./rclone.config
     rclonecmd="rclone --config=${rcloneconf}"
-    # TODO (sc-78178) customize
-    #     zone="ch-gva-2"
-    #     archiveurl=https://sos-${zone}.exo.io/${bucketname}/${repoprefix}
     $rclonecmd config create $reponame s3 provider Other env_auth true endpoint sos-ch-gva-2.exo.io location_constraint ch-gva-2 acl public-read
 
     mkdir -p $repodir
@@ -49,7 +46,7 @@ fi
     pkgname=$(echo $artifact | sed -n 's|.*/\(.*\)_[0-9]*\.[0-9]*\.[0-9]*_linux_.*\.rpm|\1|p')
     pkgarch=$(echo $artifact | sed -n 's|.*/.*_[0-9]*\.[0-9]*\.[0-9]*_linux_\(.*\)\.rpm|\1|p')
 
-    sorted_files="$(ls ${repodir}/${pkgname}_*_linux_${pkgarch}.rpm | sort --version-sort --reverse)"
+    sorted_files="$(ls ${repodir}/${pkgname}_*_linux_${pkgarch}.rpm | sort --version-sort)"
 
     # Get the count of all files
     file_count=$(echo "$sorted_files" | wc -l)
@@ -67,8 +64,7 @@ fi
 
     # remove the old signature if it exists
     rm -f ${filetosign}.asc
-    # TODO (sc-78178) uncomment
-    # gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
+    gpg --default-key=7100E8BFD6199CE0374CB7F003686F8CDE378D41 --detach-sign --armor $filetosign
 
     $rclonecmd sync -vv -P ${repodir} "${reponame}:${bucketname}/${repoprefix}"
 ) 8>/tmp/publish-rpm-artifact-to-sos.lock


### PR DESCRIPTION
We add a script that publishes releases to an SOS bucket. It first downloads the RPM repo from SOS, then deletes outdated packages, adds the new package, signs the new repo state and syncs it back to the SOS bucket.