### PR TITLE
fix: golangci-lint workflow and configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ run:
   timeout: 10m
 
 linters-settings:
-  golint:
-    min-confidence: 0.3
   goimports:
     local-prefixes: github.com/exoscale
   revive:
@@ -22,10 +20,10 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - megacheck
     - misspell
     - prealloc
     - revive
     - staticcheck
+    - stylecheck
     - unused
   disable-all: true

--- a/lint.mk
+++ b/lint.mk
@@ -1,7 +1,7 @@
-## GoLang CI Linter
+## GolangCI-Lint
 #  REF: https://github.com/golangci/golangci-lint/
 
-GOLANGCI_LINT_VERSION ?= v1.51.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 GOLANGCI_LINT_TIMEOUT ?= 5m
 GOLANGCI_LINT_CONFIG ?= go.mk/.golangci.yml
 GOLANGCI_LINT_EXTRA_ARGS ?=


### PR DESCRIPTION
- removes deprecated elements
- use a maintained version as the default

The Go team supports only the 2 latest minor versions of Go (go1.21, go1.22).

So it's recommended to use those Go versions, golangci-lint follows the same support cycle.

The first version that officially supports go1.21 is v1.54.0.
The first version that officially supports go1.22 is v1.56.0.

Otherwise, using `go install` is not the recommended way to install golangci-lint https://golangci-lint.run/welcome/install/#install-from-source