### PR TITLE
README: document how to disable automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ go.mk:
 ```
 
 You can replace the `GO_MK_REF` variable with whatever version tag, commit or branch of `go.mk` that you would like to use.
+If you need to debug `go.mk` or for some reason don't want it to update automatically each time you run a make command, you can set `GO_MK_REF` to `HEAD`.
 
 ### Initializing go.mk
 


### PR DESCRIPTION
When debugging issues with `go.mk` it may be necessary to stop make from ensuring it at a certain git ref.