### PR TITLE
release: generate CHANGELOG from git history

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -83,9 +83,9 @@ CHANGELOG_FILENAME=CHANGELOG.md
 .PHONY: prepare-release
 prepare-release:
 	@if [ -z "$(NEW_VERSION)" ]; then \
-        echo "Error: NEW_VERSION is not set. Usage: make $@ NEW_VERSION=vX.Y.Z"; \
-        exit 1; \
-    fi
+		echo "Error: NEW_VERSION is not set. Usage: make $@ NEW_VERSION=vX.Y.Z"; \
+		exit 1; \
+	fi
 	@rm $(CHANGELOG_FILENAME)
 	@git add $(CHANGELOG_FILENAME)
 	@git commit -m "Prepare release"

--- a/scripts/generate-release-notes-for-tag.sh
+++ b/scripts/generate-release-notes-for-tag.sh
@@ -12,4 +12,4 @@ fi
 
 printf "\n## %s\n" ${CURRENT_TAG}
 
-git log ${PREVIOUS_TAG}..${CURRENT_TAG} --oneline --no-decorate
+git log ${PREVIOUS_TAG}..${CURRENT_TAG} --oneline --no-decorate | sed 's/^/- /'

--- a/scripts/generate-release-notes-for-tag.sh
+++ b/scripts/generate-release-notes-for-tag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+CURRENT_TAG=$1
+
+INITIAL_COMMIT=$(git rev-list --max-parents=0 HEAD)
+
+PREVIOUS_TAG=$(git tag | sort --version-sort --reverse | awk "/^${CURRENT_TAG}$/ {getline; print}")
+
+if [ "${PREVIOUS_TAG}" = "${CURRENT_TAG}" ]; then
+    PREVIOUS_TAG=${INITIAL_COMMIT}
+fi
+
+printf "\n## %s\n" ${CURRENT_TAG}
+
+git log ${PREVIOUS_TAG}..${CURRENT_TAG} --oneline --no-decorate


### PR DESCRIPTION
Running this in the CSI repo you'd see something like this:
```
❯ make prepare-release
Error: NEW_VERSION is not set. Usage: make prepare-release NEW_VERSION=vX.Y.Z
make: *** [/home/sauterp/src/github.com/exoscale/exoscale-csi-driver/go.mk/release.mk:85: prepare-release] Error 1

❯ make prepare-release NEW_VERSION=v0.29.7
[philippsauter/sc-101978/csi-automate-manifest-release 97f6adf] Prepare release
 1 file changed, 62 deletions(-)
 delete mode 100644 CHANGELOG.md
make[1]: Entering directory '/home/sauterp/src/github.com/exoscale/exoscale-csi-driver'
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.7 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.6 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.5 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.4 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.3 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.2 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.1 >> CHANGELOG.md
./go.mk/scripts/generate-release-notes-for-tag.sh v0.29.0 >> CHANGELOG.md
make[1]: Leaving directory '/home/sauterp/src/github.com/exoscale/exoscale-csi-driver'
Deleted tag 'v0.29.7' (was 97f6adf)
[philippsauter/sc-101978/csi-automate-manifest-release f8b613b] Prepare release
 Date: Fri Jul 26 13:52:44 2024 +0200
 1 file changed, 53 insertions(+), 59 deletions(-)
```

The generated changelog will look like this https://github.com/exoscale/exoscale-csi-driver/blob/9ae7906649094e47311fff899d5499b46a9c1eb5/CHANGELOG.md