### PR TITLE
staticcheck: always install latest

### DIFF
--- a/lint.mk
+++ b/lint.mk
@@ -1,7 +1,7 @@
 ## staticcheck
 #  REF: https://staticcheck.dev/
 
-STATICCHECK_LINT_VERSION ?= 2024.1.1
+STATICCHECK_LINT_VERSION ?= latest
 STATICCHECK_LINT_EXTRA_ARGS ?=
 
 STATICCHECK_LINT ?= $(shell which staticcheck)


### PR DESCRIPTION
Staticcheck's behavior is very stable and we believe it creates less overhead if we always install the latest version instead of pinning a specific one.

```shell
❯ make lint
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@latest
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```